### PR TITLE
Bump to v3.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -36,4 +36,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,10 @@ jobs:
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
           restore-keys: ${{ runner.os }}-rubygems-
 
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottles-${{ matrix.os }}
           path: '*.bottle.*'

--- a/Casks/vpnstatus.rb
+++ b/Casks/vpnstatus.rb
@@ -1,8 +1,8 @@
 cask "vpnstatus" do
-  version "3.0"
-  sha256 "44b6c5a1e25d868ec69a3a46b75fefce476b4913fffaeb0f4d77bfdec7fc844b"
+  version "3.1"
+  sha256 "c8e484b1d911e8aaab3ca5d6c527814d61707d47e9b4c0ede98bcd156ff07ba8"
 
-  url "https://github.com/Timac/VPNStatus/releases/download/#{version}/VPNStatus.app.zip"
+  url "https://github.com/Timac/VPNStatus/releases/download/#{version}/VPNStatus.zip"
   name "VPNStatus"
   desc "Replacement for builtin VPN Status"
   homepage "https://github.com/Timac/VPNStatus"

--- a/Formula/vpnutil.rb
+++ b/Formula/vpnutil.rb
@@ -1,12 +1,12 @@
 class Vpnutil < Formula
   desc "Command-line tool that can start and stop a VPN service from the Terminal"
   homepage "https://github.com/Timac/VPNStatus"
-  url "https://github.com/Timac/VPNStatus/releases/download/3.0/vpnutil.zip"
-  sha256 "c8477df422660d917f6928d50618986b60376768106afbaca8859cb655c757f6"
+  url "https://github.com/Timac/VPNStatus/releases/download/3.1/vpnutil.zip"
+  sha256 "6eb981aebdc6e3e0209fae5a7db515a8ab7ce4d62395f685d5559edc23df4267"
   license "MIT"
 
   livecheck do
-    url :url
+    url :stable
     strategy :github_latest
   end
 
@@ -18,6 +18,6 @@ class Vpnutil < Formula
 
   test do
     # Validate install
-    system "#{bin}/vpnutil", "list"
+    system bin/"vpnutil", "list"
   end
 end


### PR DESCRIPTION
1. Bump to 3.1
2. Change livecheck to `stable`
3. Fix complaints by `brew audit --strict --online vpnutil`
4. Upgrade to `actions/upload-artifact@v4`, as v3 does not work anymore

Closes #5 